### PR TITLE
Lock the controls in visible state

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The extension provides the following shortcuts to manage the web player:
 |`m`|Toggle mute|
 |`up arrow`|Increase volume|
 |`down arrow`|Decrease volume|
+|`l`|Lock video controls as visible|
 
 ## Todo
  - [ ] Select camera view from sidebar with shortcut

--- a/modules/layout.css
+++ b/modules/layout.css
@@ -134,3 +134,15 @@
 ._2c4vB > .content-wrapper > .content-wrapper__inner > :last-child button {
     border-radius: 0;
 }
+
+/* Locked controls */
+#playerComponentContainer.locked-open .controlbar-container.hidden {
+    background-color: rgba(21, 21, 30, 0.8);
+}
+
+#playerComponentContainer.locked-open .upstairs.hidden,
+#playerComponentContainer.locked-open .downstairs.hidden {
+    opacity: 1;
+    visibility: visible;
+}
+/* /Locked controls */

--- a/modules/shortcuts.js
+++ b/modules/shortcuts.js
@@ -1,4 +1,12 @@
 (document => {
+    const toggleLockedControls = () => {
+        const player = document.querySelector("#playerComponentContainer");
+        console.log(player);
+        if (!player) return;
+
+        player.classList.toggle("locked-open");
+    };
+
     const changeVolume = deltaPercentage => () => {
         const video = document.querySelector("#hlsjsContent");
         const volumeSlider = document.querySelector(
@@ -30,7 +38,8 @@
         fullscreen: "f",
         mute: "m",
         increaseVolume: "ArrowUp",
-        decreaseVolume: "ArrowDown"
+        decreaseVolume: "ArrowDown",
+        lockControls: "l"
     };
 
     const keyMap = {
@@ -42,7 +51,8 @@
         ),
         [actionMap.mute]: clickButton("app-mute-button > div.mute-button"),
         [actionMap.increaseVolume]: changeVolume(5),
-        [actionMap.decreaseVolume]: changeVolume(-5)
+        [actionMap.decreaseVolume]: changeVolume(-5),
+        [actionMap.lockControls]: toggleLockedControls
     };
 
     document.addEventListener("keydown", e => {


### PR DESCRIPTION
Implements #1. Uses `l` as the keyboard shortcut